### PR TITLE
Update for use with Tableau SDK v2018.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,22 @@ language: node_js
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.6
+      - llvm-toolchain-trusty-5.0
     packages:
-      - clang
+      - clang-5.0
+
+env:
+  matrix:
+    - TABLEAU_SDK_VERSION=2018-3-0
 
 node_js:
-  - '4.5'
+  - '6'
+  - '8'
+  - '10'
 
 before_install:
-  - wget --directory-prefix=$HOME/tableau-c-sdk https://downloads.tableau.com/tssoftware/Tableau-SDK-Linux-64Bit-${TABLEAU_SDK_VERSION}.deb
-  - sudo dpkg -i $HOME/tableau-c-sdk/Tableau-SDK-Linux-64Bit-${TABLEAU_SDK_VERSION}.deb
+  - wget --directory-prefix=$HOME/tableau-c-sdk https://downloads.tableau.com/tssoftware/extractapi-linux-x86_64-${TABLEAU_SDK_VERSION}.deb
+  - sudo dpkg -i $HOME/tableau-c-sdk/extractapi-linux-x86_64-${TABLEAU_SDK_VERSION}.deb
 
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -64,6 +64,36 @@ pump
     });
 ```
 
+## Advanced Usage
+You can add multiple tables to your extract and insert data into specific
+tables like this.
+```javascript
+
+pump
+  .mixin(TableauExtractMixin({path: extPath, definition: extDef}))
+  .addTableToExtract(secondTableName, secondTableDef)
+  .process(function (data) {
+    if (data.hasOwnProperty('foo')) {
+      return pump.insertIntoExtract(secondTableName, data);
+    }
+    else {
+      return pump.insertIntoExtract(otherTableName, data);
+    }
+  });
+```
+
+You can also insert multiple rows of data at once (for example, using the
+node-datapumps built-in BatchMixin) like this.
+
+```javascript
+pump
+  .mixin(BatchMixin)
+  .mixin(TableauExtractMixin({path: extPath, definition: extDef}))
+  .process(function (rows) {
+    return pump.insertMultipleIntoExtract(rows);
+  });
+```
+
 For more information about how to define an extract see the Node.js
 [Tableau SDK usage details].
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Datapumps: Tableau Data Extract [![Build Status](https://travis-ci.org/tableau-mkt/datapumps-tableau-extract.svg?branch=master)](https://travis-ci.org/tableau-mkt/datapumps-tableau-extract)
+Datapumps: Tableau Extract [![Build Status](https://travis-ci.org/tableau-mkt/datapumps-tableau-extract.svg?branch=master)](https://travis-ci.org/tableau-mkt/datapumps-tableau-extract)
 ==========================
 
 [Datapumps] is a node.js ETL framework that allows you to easily import, export,
 transform, or move data between systems. This package introduces a mixin that
-can be used with datapumps to write data to a [Tableau Data Extract].
+can be used with datapumps to write data to a [Tableau Extract].
 
 ## Installation
 
@@ -41,7 +41,7 @@ pump
 
   // Write data into a TDE in the current working directory.
   .mixin(TableauExtractMixin({
-    path: 'posts.tde',
+    path: 'posts.hyper',
     definition: {
       defaultAlias: 'JSON Placeholder Posts',
       columns: [
@@ -59,7 +59,7 @@ pump
 
   .run()
     .then(function() {
-      console.log('Done writing posts to the TDE.');
+      console.log('Done writing posts to the Extract.');
       pump.closeExtract();
     });
 ```
@@ -98,6 +98,6 @@ For more information about how to define an extract see the Node.js
 [Tableau SDK usage details].
 
 [Datapumps]: https://www.npmjs.com/package/datapumps
-[Tableau Data Extract]: https://www.tableau.com/about/blog/2014/7/understanding-tableau-data-extracts-part1
+[Tableau Extract]: https://www.tableau.com/about/blog/2014/7/understanding-tableau-data-extracts-part1
 [Node.js Tableau SDK]: https://github.com/tableau-mkt/node-tableau-sdk#installation
 [Tableau SDK usage details]: https://github.com/tableau-mkt/node-tableau-sdk#usage

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Datapumps: Tableau Data Extract [![Build Status](https://travis-ci.org/tableau-m
 
 [Datapumps] is a node.js ETL framework that allows you to easily import, export,
 transform, or move data between systems. This package introduces a mixin that
-can be used with datapumps to write data to a [Tableau Data Extract] and
-optionally publish the extract to Tableau Server or Tableau Online.
+can be used with datapumps to write data to a [Tableau Data Extract].
 
 ## Installation
 
@@ -62,14 +61,11 @@ pump
     .then(function() {
       console.log('Done writing posts to the TDE.');
       pump.closeExtract();
-
-      console.log('Attempting to publish TDE to my Tableau Online site.');
-      pump.publishToServer('https://10ay.online.tableau.com', 'myUser', process.env.MYPW, 'mysite');
     });
 ```
 
-For more information about how to define an extract or publish an extract to
-Server, see the Node.js [Tableau SDK usage details].
+For more information about how to define an extract see the Node.js
+[Tableau SDK usage details].
 
 [Datapumps]: https://www.npmjs.com/package/datapumps
 [Tableau Data Extract]: https://www.tableau.com/about/blog/2014/7/understanding-tableau-data-extracts-part1

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function() {
-  var TDE = require('tableau-sdk'),
+  var ExtractApi = require('tableau-sdk'),
       Promise = require('bluebird');
 
   module.exports = function TableauExtractMixin(args) {
@@ -11,7 +11,7 @@
     }
 
     return function (target) {
-      target._tde = new TDE(args.path, args.definition);
+      target._tableauExtract = new ExtractApi(args.path, args.definition);
 
       /**
        * Insert a single row into the Tableau Data Extract.
@@ -21,29 +21,7 @@
       target.insertIntoExtract = function insertIntoExtract(row) {
         return new Promise(function (resolve, reject) {
           try {
-            target._tde.insert(row);
-            resolve();
-          }
-          catch (err) {
-            reject(err);
-          }
-        });
-      };
-
-      /**
-       * Publish the extract to an instance of Tableau Server.
-       * @param {String} host
-       * @param {String} user
-       * @param {String} password
-       * @param {String|null} site
-       * @param {String|null} project
-       * @param {bool|null} overwrite
-       * @returns Promise
-       */
-      target.publishToServer = function publishToServer(host, user, password, site, project, overwrite) {
-        return new Promise(function (resolve, reject) {
-          try {
-            target._tde.publish(host, user, password, site, project, overwrite);
+            target._tableauExtract.insert(row);
             resolve();
           }
           catch (err) {
@@ -56,7 +34,7 @@
        * Close the extract.
        */
       target.closeExtract = function closeExtract() {
-        target._tde.close();
+        target._tableauExtract.close();
       };
 
       return target;

--- a/index.js
+++ b/index.js
@@ -14,20 +14,51 @@
       target._tableauExtract = new ExtractApi(args.path, args.definition);
 
       /**
-       * Insert a single row into the Tableau Data Extract.
+       * Insert a single row into the Tableau Extract.
+       * @param {String} table
+       *   Defaults to "Extract" if no table name is provided.
        * @param {Object|Array} row
        * @returns Promise
        */
-      target.insertIntoExtract = function insertIntoExtract(row) {
+      target.insertIntoExtract = function insertIntoExtract(table, row) {
         return new Promise(function (resolve, reject) {
           try {
-            target._tableauExtract.insert(row);
+            target._tableauExtract.insert(table, row);
             resolve();
           }
           catch (err) {
             reject(err);
           }
         });
+      };
+
+      /**
+       * Insert multiple rows into the Tableau Extract.
+       * @param {String} table
+       *   Defaults to "Extract" if no table name is provided.
+       * @param {Array} rows
+       * @returns Promise
+       */
+      target.insertMultipleIntoExtract = function insertMultipleIntoExtract(table, rows) {
+        return new Promise(function (resolve, reject) {
+          try {
+            target._tableauExtract.insertMultiple(table, rows);
+          }
+          catch (err) {
+            reject(err);
+          }
+        });
+      };
+
+      /**
+       * Add an additional table to the extract.
+       * @param {String} table
+       * @param {Object} definition
+       * @returns {target}
+       */
+      target.addTableToExtract = function addTableToExtract(table, definition) {
+        target._tableauExtract.addTable(table, definition);
+        return this;
       };
 
       /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,957 @@
+{
+  "name": "datapumps-tde",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
+      "dev": true,
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
+    "arguments-extended": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
+      "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
+      "dev": true,
+      "requires": {
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.8"
+      }
+    },
+    "array-extended": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
+      "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
+      "dev": true,
+      "requires": {
+        "arguments-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.0.tgz",
+      "integrity": "sha1-n8pV5sc+G6XSlL2pmDGA6UfiEZw=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "bson": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true
+    },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=",
+      "dev": true
+    },
+    "cfb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.1.0.tgz",
+      "integrity": "sha512-ZqfxNGWTMKhd0a/n6YKJLq8hWbd5kR3cA4kXwUj9vVEdHlwJ09werR8gN15Z7Y1FTXqdD6dE3GGCxv4uc28raA==",
+      "dev": true,
+      "requires": {
+        "adler-32": "~1.2.0",
+        "commander": "^2.16.0",
+        "crc-32": "~1.2.0",
+        "printj": "~1.1.2"
+      }
+    },
+    "codepage": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.3.8.tgz",
+      "integrity": "sha1-Ty5dfAl13ij4hJgFjcta/KtqX3E=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "concat-stream": "^2.0.0",
+        "voc": "^1.1.0"
+      }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+          "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "dev": true,
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
+    "datapumps": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/datapumps/-/datapumps-0.5.1.tgz",
+      "integrity": "sha1-6EwmxrtAXAhlm6/JrbIzbI6NnpQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^2.2.2",
+        "coffee-script": "^1.7.1",
+        "excel4node": "~0.0.9",
+        "fast-csv": "~0.5.2",
+        "mongodb": "^2.2.24",
+        "mysql": "~2.5.1",
+        "pg": "^6.1.5",
+        "restler": "~3.2.2",
+        "xlsx": "~0.7.8"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        }
+      }
+    },
+    "date-extended": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
+      "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
+      "dev": true,
+      "requires": {
+        "array-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "declare.js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/declare.js/-/declare.js-0.0.8.tgz",
+      "integrity": "sha1-BHit/5VkwAT1Hfc9i8E0AZ0o3N4=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.2.1",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "excel4node": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npmjs.org/excel4node/-/excel4node-0.0.10.tgz",
+      "integrity": "sha1-dgAgRNU/TVCWYLQzIMTFkZtWXaw=",
+      "dev": true,
+      "requires": {
+        "image-size": "~0.3.1",
+        "jszip": "~2.3.0",
+        "mime": "~1.2.11",
+        "xmlbuilder": "~2.2.1"
+      }
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "dev": true
+    },
+    "extended": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
+      "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
+      "dev": true,
+      "requires": {
+        "extender": "~0.0.5"
+      }
+    },
+    "extender": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
+      "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
+      "dev": true,
+      "requires": {
+        "declare.js": "~0.0.4"
+      }
+    },
+    "fast-csv": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-0.5.7.tgz",
+      "integrity": "sha1-4l5x5aMPUcMvcWL+qrxcBTGxr1k=",
+      "dev": true,
+      "requires": {
+        "extended": "0.0.6",
+        "is-extended": "0.0.10",
+        "object-extended": "0.0.7",
+        "string-extended": "0.0.8"
+      }
+    },
+    "frac": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-0.3.1.tgz",
+      "integrity": "sha1-V3Z3t/3L5vr3xGHxgB00E3zaQ1Q=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "generic-pool": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
+      "integrity": "sha1-eAw29p360FpaBF3Te+etyhGk9v8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "image-size": {
+      "version": "0.3.5",
+      "resolved": "http://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+      "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-extended": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
+      "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
+      "dev": true,
+      "requires": {
+        "extended": "~0.0.3"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jszip": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.3.0.tgz",
+      "integrity": "sha1-BO+g+E2tgqK7PTOrl7ns5bl2mTY=",
+      "dev": true,
+      "requires": {
+        "pako": "~0.2.1"
+      }
+    },
+    "lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha1-6oL3sQDHM9GkKvdoAeUGEF4qgOw=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        }
+      }
+    },
+    "moment": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
+      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+    },
+    "mongodb": {
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
+      "dev": true,
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.20",
+        "readable-stream": "2.2.7"
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+      "dev": true,
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mysql": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.5.5.tgz",
+      "integrity": "sha1-AqHE0GF/t3HYXBX88k0Qj1pi9kg=",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "2.0.0",
+        "readable-stream": "~1.1.13",
+        "require-all": "~1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+      "dev": true
+    },
+    "object-extended": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
+      "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
+      "dev": true,
+      "requires": {
+        "array-extended": "~0.0.4",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "packet-reader": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=",
+      "dev": true
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pg": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
+      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "1.0.1",
+        "js-string-escape": "1.0.1",
+        "packet-reader": "0.3.1",
+        "pg-connection-string": "0.1.3",
+        "pg-pool": "1.*",
+        "pg-types": "1.*",
+        "pgpass": "1.*",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
+          "dev": true
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.8.0.tgz",
+      "integrity": "sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=",
+      "dev": true,
+      "requires": {
+        "generic-pool": "2.4.3",
+        "object-assign": "4.1.0"
+      }
+    },
+    "pg-types": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
+      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "dev": true,
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
+    "postgres-array": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
+      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
+      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "qs": {
+      "version": "0.6.6",
+      "resolved": "http://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+      "dev": true,
+      "requires": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "require-all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/require-all/-/require-all-1.0.0.tgz",
+      "integrity": "sha1-hINwjnzkxt+tmItQgPl4KbktIic=",
+      "dev": true
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "dev": true
+    },
+    "restler": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-3.2.2.tgz",
+      "integrity": "sha1-9sUyuTd0YJPjSGOH5X+xBRvbKFc=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.2.11",
+        "qs": "0.6.6",
+        "xml2js": "0.4.0",
+        "yaml": "0.2.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "sax": {
+      "version": "0.5.8",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "ssf": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.8.2.tgz",
+      "integrity": "sha1-udTcahwbz3b4q/qW19dlb7Kr7NY=",
+      "dev": true,
+      "requires": {
+        "colors": "0.6.2",
+        "frac": "0.3.1",
+        "voc": "^1.1.0"
+      }
+    },
+    "string-extended": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
+      "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
+      "dev": true,
+      "requires": {
+        "array-extended": "~0.0.5",
+        "date-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tableau-sdk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tableau-sdk/-/tableau-sdk-1.1.0.tgz",
+      "integrity": "sha512-/MQSg/Ykg9jKQK+H116qsf81A6IZspIUYNq5QLJSWz2HnvzjQvOg8ji8ZmVG9p1cfggPqMB3KVOFBpZboVV98g==",
+      "requires": {
+        "moment": "^2.14.1",
+        "underscore": "^1.8.3"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "voc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/voc/-/voc-1.1.0.tgz",
+      "integrity": "sha512-fthgd8OJLqq8vPcLjElTk6Rcl2e3v5ekcXauImaqEnQqd5yUWKg1+ZOBgS2KTWuVKcuvZMQq4TDptiT1uYddUA==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xlsx": {
+      "version": "0.7.12",
+      "resolved": "http://registry.npmjs.org/xlsx/-/xlsx-0.7.12.tgz",
+      "integrity": "sha1-cUSDHY7NScBiFB98SJddGkAJiOQ=",
+      "dev": true,
+      "requires": {
+        "adler-32": "^1.2.0",
+        "cfb": ">=0.10.0",
+        "codepage": "~1.3.6",
+        "commander": "^2.19.0",
+        "crc-32": "^1.2.0",
+        "jszip": "2.4.0",
+        "ssf": "~0.8.1"
+      },
+      "dependencies": {
+        "jszip": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.4.0.tgz",
+          "integrity": "sha1-SHqTt2w7/6bLCFzWHrk06r4tKU8=",
+          "dev": true,
+          "requires": {
+            "pako": "~0.2.5"
+          }
+        }
+      }
+    },
+    "xml2js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.0.tgz",
+      "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
+      "dev": true,
+      "requires": {
+        "sax": "0.5.x",
+        "xmlbuilder": ">=0.4.2"
+      }
+    },
+    "xmlbuilder": {
+      "version": "2.2.1",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
+      "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI=",
+      "dev": true,
+      "requires": {
+        "lodash-node": "~2.4.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yaml": {
+      "version": "0.2.3",
+      "resolved": "http://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,10 +18,14 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "*",
-    "tableau-sdk": "^0.2.0"
+    "tableau-sdk": "^1.1.0"
+  },
+  "peerDependencies": {
+    "datapumps": "^0.4.6"
   },
   "devDependencies": {
-    "datapumps": "^0.4.6",
-    "mocha": "^3.0.2"
+    "datapumps": "^0.5.1",
+    "fs-extra": "^7.0.1",
+    "mocha": "^5.2.0"
   }
 }

--- a/test/TableauExtractMixin.js
+++ b/test/TableauExtractMixin.js
@@ -4,25 +4,38 @@ var fs = require('fs-extra'),
     assert = require('assert'),
     datapumps = require('datapumps'),
     RestMixin = datapumps.mixin.RestMixin,
+    MergeMixin = datapumps.mixin.MergeMixin,
     TableauExtractMixin = require('../index.js');
 
 describe('TableauExtractMixin', function() {
   var targetDir = './test/build',
       expectedPath,
-      tableDef;
+      tableDefs;
 
-  // These tests actually read/write from/to disk. Account for slowness here.
-  this.timeout(10000);
+  // These tests actually read/write from/to disk/network.
+  // Account for slowness here.
+  this.timeout(60000);
 
   // Table definition isn't changing. Define it here.
-  tableDef = {
-    columns: [
-      {id: 'albumId', dataType: 'int'},
-      {id: 'id', dataType: 'int'},
-      {id: 'title', dataType: 'string'},
-      {id: 'url', dataType: 'string'},
-      {id: 'thumbnailUrl', dataType: 'string'}
-    ]
+  tableDefs = {
+    photos: {
+      id: 'Photos',
+      columns: [
+        {id: 'albumId', dataType: 'int'},
+        {id: 'id', dataType: 'int'},
+        {id: 'title', dataType: 'string'},
+        {id: 'url', dataType: 'string'},
+        {id: 'thumbnailUrl', dataType: 'string'}
+      ]
+    },
+    albums: {
+      id: 'Albums',
+      columns: [
+        {id: 'userId', dataType: 'int'},
+        {id: 'id', dataType: 'int'},
+        {id: 'title', dataType: 'string'}
+      ]
+    }
   };
 
   before(function() {
@@ -34,7 +47,7 @@ describe('TableauExtractMixin', function() {
     process.env['TAB_SDK_TMPDIR'] = targetDir;
   });
 
-  it('pumps data into a TDE', function (done) {
+  it('pumps data into an extract', function (done) {
     var pump = new datapumps.Pump(),
         apiUrl = 'https://jsonplaceholder.typicode.com/photos',
         beforeSize,
@@ -58,9 +71,9 @@ describe('TableauExtractMixin', function() {
       })
 
       // Write data into a Tableau Data Extract file.
-      .mixin(TableauExtractMixin({path: expectedPath, definition: tableDef}))
-      .process(function (post) {
-        return pump.insertIntoExtract(post);
+      .mixin(TableauExtractMixin({path: expectedPath, definition: tableDefs.photos}))
+      .process(function (photo) {
+        return pump.insertIntoExtract(tableDefs.photos.id, photo);
       })
 
       // Test Assertions here.
@@ -72,7 +85,59 @@ describe('TableauExtractMixin', function() {
         afterSize = fs.statSync(expectedPath)['size'];
 
         // Ensure that the file grew in size from the original measurement.
-        assert(beforeSize < afterSize, 'TDE increased in size');
+        assert(beforeSize < afterSize, 'Extract increased in size');
+        done();
+      })
+
+      // Run the damn thing.
+      .run()
+  });
+
+  it('pumps data into a multi-table extract', function (done) {
+    var pump = new datapumps.Pump(),
+        apiUrl = 'https://jsonplaceholder.typicode.com',
+        beforeSize,
+        afterSize;
+
+    // Set the path here.
+    expectedPath = targetDir + '/mocha-pumps-data-into-multi-table.hyper';
+
+    // Start defining the datapump.
+    pump
+
+      // Pull data from several REST APIs.
+      .mixin(MergeMixin)
+      .mixin(RestMixin)
+      .fromRest({
+        query: function () {return pump.get(apiUrl + '/albums');},
+        resultMapping: function (message) {
+          // Get a baseline size of the TDE here.
+          beforeSize = fs.statSync(expectedPath)['size'];
+          return message.result;
+        }
+      })
+
+      // Write data into a Tableau Data Extract file.
+      .mixin(TableauExtractMixin({path: expectedPath, definition: tableDefs.photos}))
+      .addTableToExtract('Albums', tableDefs.albums)
+      .process(function (album) {
+        return pump.get(apiUrl + '/photos?albumId=' + album.id)
+          .then(function (response) {
+            pump.insertMultipleIntoExtract('Photos', response.result);
+            return pump.insertIntoExtract('Albums', album);
+          });
+      })
+
+      // Test Assertions here.
+      .on('end', function () {
+        // Close the extract (otherwise nothing is actually written to the TDE).
+        pump.closeExtract();
+
+        // Read the file size of the extract now.
+        afterSize = fs.statSync(expectedPath)['size'];
+
+        // Ensure that the file grew in size from the original measurement.
+        assert(beforeSize < afterSize, 'Extract increased in size');
         done();
       })
 


### PR DESCRIPTION
- Drops support for publishing to Tableau Server (use the REST API to do this instead).
- Adds support for multi-table extracts.
- Adds support for multi-row inserts.
- Adds official support for node v6, v8, and v10.