### PR TITLE
Add a method that persists inserted rows to disk

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,23 @@
       };
 
       /**
+       * Write all rows that have been inserted into the extract to disk.
+       * @returns Promise
+       */
+      target.writeExtractToDisk = function writeExtractToDisk() {
+        return new Promise(function (resolve, reject) {
+          try {
+            target._tableauExtract.close();
+            target._tableauExtract = new ExtractApi(args.path, args.definition);
+            resolve();
+          }
+          catch (err) {
+            reject(err);
+          }
+        })
+      }
+
+      /**
        * Close the extract.
        */
       target.closeExtract = function closeExtract() {


### PR DESCRIPTION
Adds `pump.writeExtractToDisk()`, which closes and re-opens the extract, forcing any insert rows to be persisted to disk.  This can be useful in scenarios where you are writing huge amounts of data to the extract.